### PR TITLE
Extend Solaris 10s timeout from 3h to 10h

### DIFF
--- a/sample/build-ruby
+++ b/sample/build-ruby
@@ -124,7 +124,9 @@ when 'scw-9d6766', 'tk2-243-31075', 'armv8b'
 end
 
 case ChkBuild.nickname
-when 'unstable10s', 'scw-9d6766'
+when 'unstable10s'
+  h[:timeout] = '10h'
+when 'scw-9d6766'
   h[:timeout] = '3h'
 end
 


### PR DESCRIPTION
`make test-all` on Solaris 10s fails due to timeout with progress [11297/20889].  I think it requires roughly 2x longer timeout at least.

https://rubyci.org/logs/rubyci.s3.amazonaws.com/amazon/ruby-trunk/log/20190524T123003Z.fail.html.gz