### PR TITLE
Use `git clone --depth=1` in Solaris

### DIFF
--- a/chkbuild/git.rb
+++ b/chkbuild/git.rb
@@ -81,6 +81,7 @@ class ChkBuild::IBuild
     FileUtils.mkdir_p(pdir) if !File.directory?(pdir)
     git_logfile(opts) {|opts2|
       command = ["git", "clone", "-q"]
+      command << "--depth=1" if opts[:git_shallow_clone]
       command << '--branch' << branch if branch
       command << cloneurl
       command << working_dir

--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -730,6 +730,8 @@ def (ChkBuild::Ruby).build_proc(b)
     if ruby_version.before(1,9,3)
       # "make dist" doesn't support BRANCH@rev.
       relname = nil
+    elsif bopts[:git_shallow_clone]
+      relname = nil
     else
       # "make dist" support BRANCH@rev since Ruby 1.9.3.
       relname = "#{ruby_branch}@#{ruby_rev}"

--- a/chkbuild/upload.rb
+++ b/chkbuild/upload.rb
@@ -183,6 +183,7 @@ module ChkBuild
   #  :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY'])
 
   def self.s3_upload_target
+    return if ENV["DISABLE_S3_UPLOAD"] # for local test
     bucket_name = 'rubyci'
     region = 'ap-northeast-1'
     require 'aws-sdk'

--- a/sample/build-ruby
+++ b/sample/build-ruby
@@ -117,6 +117,7 @@ when /\ASunOS/
 #  h[:configure_args_cc] = %w[CC=/opt/solarisstudio12.4/bin/cc]
   arg[0].slice!(1,9)
   h[:optflags] = '-O3 -mfpmath=sse -msse2' if /i86/ =~ uname
+  h[:git_shallow_clone] = true
 end
 
 case ChkBuild.nickname

--- a/sample/build-ruby
+++ b/sample/build-ruby
@@ -78,6 +78,7 @@ ChkBuild::Ruby.def_target(
 
   # [nil, { :suffix_? => "-outofplace", :inplace_build => false}]
 
+  # :git_shallow_clone => true,
   # :autoconf_command => 'autoconf',
   # :configure_args_valgrind => %w[--with-valgrind],
   # :configure_args_enable_shared => %w[--enable-shared],


### PR DESCRIPTION
Because of very frequent timeout failures to git clone.